### PR TITLE
Generate JSON output

### DIFF
--- a/ext-stats/hackage-download.sh
+++ b/ext-stats/hackage-download.sh
@@ -3,29 +3,35 @@
 [ -e 00-index.tar.gz ] || wget hackage.haskell.org/00-index.tar.gz
 
 # get latest version each
-echo -n "Reading package list …"
+echo "Reading package list …"
 pkgs_files=$(tar tzf 00-index.tar.gz | grep -v preferred-versions | sort -k1,1 -k2,2rV -t'/' --stable | sort -k1,1 -t'/' --stable --unique)
 
-selected_pkgs=()
-for pkg_file in $pkgs_files
-do
-  # if grep -q -e '[, ]containers\([, ]\|$\)' 01-index/$pkg_file
-  # then
-    pkg="$(echo "$pkg_file" | cut -d/ -f1,2|tr / -)"
-    selected_pkgs+=("$pkg")
-  #fi
-done
-echo " done (${#selected_pkgs[@]} packages)"
+packages() {
+  selected_pkgs=()
+  for pkg_file in $pkgs_files
+  do
+    # if grep -q -e '[, ]containers\([, ]\|$\)' 01-index/$pkg_file
+    # then
+      pkg="$(echo "$pkg_file" | cut -d/ -f1,2|tr / -)"
+      selected_pkgs+=("$pkg")
+      echo $pkg
+    #fi
+  done
+  # echo " done (${#selected_pkgs[@]} packages)"
+}
 
 mkdir -p hackage/
 
 # for debugging
 # selected_pkgs=("${selected_pkgs[@]:0:200}")
 
-for pkg in "${selected_pkgs[@]}"
-do
+unpack() {
+  pkg=$1
   if [ ! -e "hackage/$pkg" ]
   then
     ( cd "hackage" && cabal unpack "$pkg" )
   fi
-done
+}
+export -f unpack
+
+packages | parallel -j8 unpack


### PR DESCRIPTION
Generate summary output as JSON.

I imagine this would make it easier to analyze after the fact. Example output:

```
{
  "enabled-in-file": {
    "turned-on": {
      "OverloadedLabels": 1,
      "GeneralizedNewtypeDeriving": 7,
      "TemplateHaskell": 5,
...
    "turned-off": {
      "ImplicitPrelude": 7,
      "MonomorphismRestriction": 2
    }
  },
  "enabled-in-cabal": {
    "turned-on": {
      "OverloadedLabels": 2,
      "GeneralizedNewtypeDeriving": 25,
...
    "turned-off": {
      "ImplicitPrelude": 16,
      "MonomorphismRestriction": 7
    }
  }
}
```
I think there might be a problem with the `Ord` instance for `OnOffExtension` making it unsuitable for use in a `Set`.
